### PR TITLE
Allow site to run properly behind an Nginx proxy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -349,7 +349,7 @@
 
           // apply custom CSS
           $.each( data.css, function ( key, cssFile ) {
-            url = '/css/'+cssFile;
+            url = 'css/'+cssFile;
             link = '<link rel="stylesheet" type="text/css" href='+url+'>';
             $(link).appendTo('head');
           });


### PR DESCRIPTION
I have an Nginx server setup such that https://example.com/starbound works for CommandStar with the following rules:

```
location /starbound/ {
    rewrite ^/starbound/(.*) /$1 break;
    proxy_pass http://127.0.0.1:8080;
    include proxy.conf;
}
```

Since the CommandStar HTML was referencing absolute paths ("/css/", etc.), my rewrite was failing to pull in any additional assets or load the API, etc. With this change, everything works with the proxy remap to /starbound/.
